### PR TITLE
Githubへのリンク用Component作成

### DIFF
--- a/components/GithubLink.vue
+++ b/components/GithubLink.vue
@@ -12,12 +12,23 @@
 <script>
 export default
 {
+    props:
+    {
+        user: String,
+        repository: String,
+    },
     data()
     {
+        var url = "https://github.com/";
+        if(this.user != undefined && this.repository != undefined)
+        {
+            url += this.user + "/";
+            url += this.repository;
+        }
         return {
             DisplayText: "GitHub",
-            Link: "https://github.com/nuxt/nuxt.js"
+            Link: url
         }
-    }
+    },
 }
 </script>

--- a/components/GithubLink.vue
+++ b/components/GithubLink.vue
@@ -1,17 +1,23 @@
 <template>
     <a
-        href="https://github.com/nuxt/nuxt.js"
+        :href=Link
         target="_blank"
         rel="noopener noreferrer"
         class="button--grey"
     >
-        GitHub
+        {{DisplayText}}
     </a>
 </template>
 
 <script>
 export default
 {
-    
+    data()
+    {
+        return {
+            DisplayText: "GitHub",
+            Link: "https://github.com/nuxt/nuxt.js"
+        }
+    }
 }
 </script>

--- a/components/GithubLink.vue
+++ b/components/GithubLink.vue
@@ -1,11 +1,11 @@
 <template>
     <a
-        :href=Link
+        :href=link
         target="_blank"
         rel="noopener noreferrer"
         class="button--grey"
     >
-        {{DisplayText}}
+        {{displayText}}
     </a>
 </template>
 
@@ -26,8 +26,8 @@ export default
             url += this.repository;
         }
         return {
-            DisplayText: "GitHub",
-            Link: url
+            displayText: "GitHub",
+            link: url
         }
     },
 }

--- a/components/GithubLink.vue
+++ b/components/GithubLink.vue
@@ -1,0 +1,17 @@
+<template>
+    <a
+        href="https://github.com/nuxt/nuxt.js"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="button--grey"
+    >
+        GitHub
+    </a>
+</template>
+
+<script>
+export default
+{
+    
+}
+</script>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -14,21 +14,22 @@
         >
           Documentation
         </a>
-        <a
-          href="https://github.com/nuxt/nuxt.js"
-          target="_blank"
-          rel="noopener noreferrer"
-          class="button--grey"
-        >
-          GitHub
-        </a>
+        <github-link />
       </div>
     </div>
   </div>
 </template>
 
 <script>
-export default {}
+import GithubLink from '~/components/GithubLink.vue';
+  
+export default
+{
+  components:
+  {
+    GithubLink
+  }
+}
 </script>
 
 <style>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -14,7 +14,10 @@
         >
           Documentation
         </a>
-        <github-link />
+        <github-link
+          user="nuxt"
+          repository="nuxt.js"
+        />
       </div>
     </div>
   </div>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -15,8 +15,8 @@
           Documentation
         </a>
         <github-link
-          user="nuxt"
-          repository="nuxt.js"
+          user="YanaPIIDXer"
+          repository="NuxtTest"
         />
       </div>
     </div>


### PR DESCRIPTION
Close #1 

# 概要
Githubへのリンク用Comopnentを作成。

# 詳細
- Nuxtのデフォルトページに置いてあったGithubへのリンクをComponent化した。
- 外部からユーザ名とリポジトリ名を指定してURLを生成するようにした。（どちらかの指定がない場合はgithubのトップページへ。）
- 試しにデフォルトページに置いてあるリンクをこのプロジェクトのリポジトリへのリンクに差し替え。